### PR TITLE
Support scaling values and calibrating sensor offsets

### DIFF
--- a/src/accel.rs
+++ b/src/accel.rs
@@ -28,6 +28,14 @@ impl Accel {
     pub fn z(&self) -> i16 {
         self.z
     }
+
+    pub fn scaled(&self, scale: AccelFullScale) -> AccelF32 {
+        AccelF32 {
+            x: scale.scale_value(self.x),
+            y: scale.scale_value(self.y),
+            z: scale.scale_value(self.z),
+        }
+    }
 }
 
 #[derive(Copy, Clone, Debug)]
@@ -36,4 +44,39 @@ pub enum AccelFullScale {
     G4 = 1,
     G8 = 2,
     G16 = 3,
+}
+
+impl AccelFullScale {
+    pub const fn scale(self) -> f32 {
+        match self {
+            AccelFullScale::G2 => 16384.0,
+            AccelFullScale::G4 => 8192.0,
+            AccelFullScale::G8 => 4096.0,
+            AccelFullScale::G16 => 2048.0,
+        }
+    }
+
+    pub fn scale_value(self, value: i16) -> f32 {
+        (value as f32) / self.scale()
+    }
+}
+
+pub struct AccelF32 {
+    x: f32,
+    y: f32,
+    z: f32,
+}
+
+impl AccelF32 {
+    pub fn x(&self) -> f32 {
+        self.x
+    }
+
+    pub fn y(&self) -> f32 {
+        self.y
+    }
+
+    pub fn z(&self) -> f32 {
+        self.z
+    }
 }

--- a/src/accel.rs
+++ b/src/accel.rs
@@ -1,12 +1,18 @@
-#[derive(Copy, Clone, Debug)]
+/// Raw acceleration readings vector.
+/// Also used to represent acceleration calibration offsets.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct Accel {
-    x: i16,
-    y: i16,
-    z: i16,
+    pub(crate) x: i16,
+    pub(crate) y: i16,
+    pub(crate) z: i16,
 }
 
 impl Accel {
-    pub(crate) fn new(data: [u8; 6]) -> Self {
+    pub fn new(x: i16, y: i16, z: i16) -> Self {
+        Self { x, y, z }
+    }
+
+    pub fn from_bytes(data: [u8; 6]) -> Self {
         let x = [data[0], data[1]];
         let y = [data[2], data[3]];
         let z = [data[4], data[5]];
@@ -15,6 +21,13 @@ impl Accel {
             y: i16::from_be_bytes(y),
             z: i16::from_be_bytes(z),
         }
+    }
+
+    pub fn to_bytes(&self) -> [u8; 6] {
+        let x = self.x.to_be_bytes();
+        let y = self.y.to_be_bytes();
+        let z = self.z.to_be_bytes();
+        [x[0], x[1], y[0], y[1], z[0], z[1]]
     }
 
     pub fn x(&self) -> i16 {

--- a/src/calibration.rs
+++ b/src/calibration.rs
@@ -1,0 +1,476 @@
+use crate::{
+    accel::{Accel, AccelFullScale},
+    error::Error,
+    gyro::{Gyro, GyroFullScale},
+    sensor::Mpu6050,
+};
+use embedded_hal::blocking::delay::DelayMs;
+use embedded_hal::blocking::i2c::{Write, WriteRead};
+
+// The threshold value that average readings must not cross after calibration.
+#[derive(Copy, Clone, Debug)]
+pub struct CalibrationThreshold {
+    value: i16,
+}
+
+impl CalibrationThreshold {
+    // Reasonable acceleration threshold value at a given scale.
+    pub const fn from_accel_scale(scale: AccelFullScale) -> Self {
+        Self {
+            value: match scale {
+                AccelFullScale::G2 => 8,
+                AccelFullScale::G4 => 4,
+                AccelFullScale::G8 => 2,
+                AccelFullScale::G16 => 1,
+            },
+        }
+    }
+
+    // Reasonable gyro threshold value at a given scale.
+    pub const fn from_gyro_scale(scale: GyroFullScale) -> Self {
+        Self {
+            value: match scale {
+                _ => 1,
+            },
+        }
+    }
+
+    /// Get the threshold value
+    pub fn value(&self) -> i16 {
+        self.value
+    }
+
+    /// Check if the given value is within the threshold
+    fn is_value_within(self, value: i16) -> bool {
+        value.abs() <= self.value
+    }
+
+    /// Check if the given acceleration vector is within the threshold
+    pub fn is_accel_within(self, accel: &Accel) -> bool {
+        self.is_value_within(accel.x())
+            && self.is_value_within(accel.y())
+            && self.is_value_within(accel.z())
+    }
+
+    /// Check if the given gyro vector is within the threshold
+    pub fn is_gyro_within(self, gyro: &Gyro) -> bool {
+        self.is_value_within(gyro.x())
+            && self.is_value_within(gyro.y())
+            && self.is_value_within(gyro.z())
+    }
+
+    /// If the current computed mean value is not acceptable, compute the next likely
+    /// calibration offset.
+    ///
+    /// This is technically the single step of a PID controller where we are using only
+    /// the `I` part (`D` is not needed because calibration is not time-dependent,
+    /// and `P` because noise is mitigated by working on averages).
+    pub fn next_offset(self, current_mean: i16, current_offset: i16) -> i16 {
+        // In this PID controller the "error" is the observed average (when the calibration
+        // is correct the average is espected to be zero, or anyway within the given threshold).
+        if self.is_value_within(current_mean) {
+            // If we are withing the expected threshold do not change the offset (there's no need!).
+            current_offset
+        } else {
+            // Otherwise adjust the offset.
+            //
+            // The current measured mean value is the PID error, and the Ki PID factor is -0.1
+            // (we are dividing `current_mean` by 10).
+            //
+            // The `signum` factor is there because we work in the integer domain and if the error
+            // is small `current_mean / 10` is zero and the algorithm does not make progress.
+            // Adding the `signum` is negligible during normal operation but ensures that the offset
+            // keeps changing during the final tuning runs (when the error is already very small).
+            current_offset - ((current_mean / 10) + current_mean.signum())
+        }
+    }
+}
+
+/// Symbolic representation of a gravity vector aligned to one of the axes
+/// (gravity must be subtracted to acceleration readings during calibration)
+#[derive(Copy, Clone, Debug)]
+pub enum ReferenceGravity {
+    Zero,
+    XN,
+    XP,
+    YN,
+    YP,
+    ZN,
+    ZP,
+}
+
+impl ReferenceGravity {
+    /// Actual `g` value at a given scale
+    fn gravity_value(scale: AccelFullScale) -> i16 {
+        match scale {
+            AccelFullScale::G2 => 16384,
+            AccelFullScale::G4 => 8192,
+            AccelFullScale::G8 => 4096,
+            AccelFullScale::G16 => 2048,
+        }
+    }
+
+    /// Acceleration vector representing gravity compensation in the given direction
+    pub fn gravity_compensation(self, scale: AccelFullScale) -> Accel {
+        match self {
+            ReferenceGravity::Zero => Accel::new(0, 0, 0),
+            ReferenceGravity::XN => Accel::new(-Self::gravity_value(scale), 0, 0),
+            ReferenceGravity::XP => Accel::new(Self::gravity_value(scale), 0, 0),
+            ReferenceGravity::YN => Accel::new(0, -Self::gravity_value(scale), 0),
+            ReferenceGravity::YP => Accel::new(0, Self::gravity_value(scale), 0),
+            ReferenceGravity::ZN => Accel::new(0, 0, -Self::gravity_value(scale)),
+            ReferenceGravity::ZP => Accel::new(0, 0, Self::gravity_value(scale)),
+        }
+    }
+}
+
+/// Bit flags stating which axes must still be calibrated
+/// (six bits are used: acceleration x, y, z and gyro x, y, z)
+#[derive(Copy, Clone, Debug)]
+pub struct CalibrationActions {
+    flags: u8,
+}
+
+impl CalibrationActions {
+    const ACCEL_X: u8 = 1 << 0;
+    const ACCEL_Y: u8 = 1 << 1;
+    const ACCEL_Z: u8 = 1 << 2;
+    const GYRO_X: u8 = 1 << 3;
+    const GYRO_Y: u8 = 1 << 4;
+    const GYRO_Z: u8 = 1 << 5;
+
+    /// Build an empty bit set
+    pub fn empty() -> Self {
+        Self { flags: 0 }
+    }
+
+    /// Build a full bit set
+    pub fn all() -> Self {
+        Self { flags: 0x3f }
+    }
+
+    /// Check if we have nothing more to calibrate
+    pub fn is_empty(self) -> bool {
+        self.flags == 0
+    }
+
+    /// Check if acceleration x axis calibration is required
+    pub fn accel_x(self) -> bool {
+        self.flags & Self::ACCEL_X != 0
+    }
+    /// Check if acceleration y axis calibration is required
+    pub fn accel_y(self) -> bool {
+        self.flags & Self::ACCEL_Y != 0
+    }
+    /// Check if acceleration z axis calibration is required
+    pub fn accel_z(self) -> bool {
+        self.flags & Self::ACCEL_Z != 0
+    }
+    /// Check if gyro x axis calibration is required
+    pub fn gyro_x(self) -> bool {
+        self.flags & Self::GYRO_X != 0
+    }
+    /// Check if gyro y axis calibration is required
+    pub fn gyro_y(self) -> bool {
+        self.flags & Self::GYRO_Y != 0
+    }
+    /// Check if gyro z axis calibration is required
+    pub fn gyro_z(self) -> bool {
+        self.flags & Self::GYRO_Z != 0
+    }
+
+    /// Set the given flag
+    fn with_flag(self, value: bool, flag: u8) -> Self {
+        Self {
+            flags: if value {
+                self.flags | flag
+            } else {
+                self.flags & !flag
+            },
+        }
+    }
+
+    /// Set acceleration x flag
+    pub fn with_accel_x(self, value: bool) -> Self {
+        self.with_flag(value, Self::ACCEL_X)
+    }
+    /// Set acceleration y flag
+    pub fn with_accel_y(self, value: bool) -> Self {
+        self.with_flag(value, Self::ACCEL_Y)
+    }
+    /// Set acceleration z flag
+    pub fn with_accel_z(self, value: bool) -> Self {
+        self.with_flag(value, Self::ACCEL_Z)
+    }
+    /// Set gyro x flag
+    pub fn with_gyro_x(self, value: bool) -> Self {
+        self.with_flag(value, Self::GYRO_X)
+    }
+    /// Set gyro y flag
+    pub fn with_gyro_y(self, value: bool) -> Self {
+        self.with_flag(value, Self::GYRO_Y)
+    }
+    /// Set gyro z flag
+    pub fn with_gyro_z(self, value: bool) -> Self {
+        self.with_flag(value, Self::GYRO_Z)
+    }
+}
+
+/// Calibration parameters.
+/// (all the values that influence calibration and do not change between calibration loop runs)
+#[derive(Copy, Clone, Debug)]
+pub struct CalibrationParameters {
+    /// Acceleration scale
+    pub accel_scale: AccelFullScale,
+    /// Acceleration threshold value
+    pub accel_threshold: CalibrationThreshold,
+    /// Gyro scale
+    pub gyro_scale: GyroFullScale,
+    /// Gyro threshold value
+    pub gyro_threshold: CalibrationThreshold,
+    /// Number of warmup iterations when computing mean values
+    pub warmup_iterations: usize,
+    /// Number of warmup iterations when computing values
+    pub iterations: usize,
+    /// Reference gravity (will be subtracted from acceleration readings)
+    pub gravity: ReferenceGravity,
+}
+
+impl CalibrationParameters {
+    /// Create calibration parameters given accel and gyro scale and a reference gravity
+    /// (sensible defaults are used for all other parameters)
+    pub fn new(
+        accel_scale: AccelFullScale,
+        gyro_scale: GyroFullScale,
+        gravity: ReferenceGravity,
+    ) -> Self {
+        Self {
+            accel_scale,
+            accel_threshold: CalibrationThreshold::from_accel_scale(accel_scale),
+            gyro_scale,
+            gyro_threshold: CalibrationThreshold::from_gyro_scale(gyro_scale),
+            warmup_iterations: WARMUP_ITERATIONS,
+            iterations: ITERATIONS,
+            gravity,
+        }
+    }
+
+    /// Change acceleration threshold
+    /// (consumes and returns `Self` to be callable in a "builder-like" pattern)
+    pub fn with_accel_threshold(self, threshold: i16) -> Self {
+        Self {
+            accel_threshold: CalibrationThreshold { value: threshold },
+            ..self
+        }
+    }
+
+    /// Change gyro threshold
+    /// (consumes and returns `Self` to be callable in a "builder-like" pattern)
+    pub fn with_gyro_threshold(self, threshold: i16) -> Self {
+        Self {
+            gyro_threshold: CalibrationThreshold { value: threshold },
+            ..self
+        }
+    }
+
+    /// Change warmup iterations count
+    /// (consumes and returns `Self` to be callable in a "builder-like" pattern)
+    pub fn with_warmup_iterations(self, warmup_iterations: usize) -> Self {
+        Self {
+            warmup_iterations,
+            ..self
+        }
+    }
+
+    /// Change iterations count
+    /// (consumes and returns `Self` to be callable in a "builder-like" pattern)
+    pub fn with_iterations(self, iterations: usize) -> Self {
+        Self { iterations, ..self }
+    }
+}
+
+/// Holds temporary vaues during sample mean computation
+/// (includes the reference gravity compensation for simplicity)
+pub struct MeanAccumulator {
+    pub ax: i32,
+    pub ay: i32,
+    pub az: i32,
+    pub gx: i32,
+    pub gy: i32,
+    pub gz: i32,
+    pub gravity_compensation: Accel,
+}
+
+impl MeanAccumulator {
+    /// Initializes the means with zero values
+    /// (and also fixes the reference gravity compensation)
+    pub fn new(accel_scale: AccelFullScale, gravity: ReferenceGravity) -> Self {
+        Self {
+            ax: 0,
+            ay: 0,
+            az: 0,
+            gx: 0,
+            gy: 0,
+            gz: 0,
+            gravity_compensation: gravity.gravity_compensation(accel_scale),
+        }
+    }
+
+    /// Adds a new sample (subtracting the reference gravity)
+    pub fn add(&mut self, accel: &Accel, gyro: &Gyro) {
+        self.ax += (accel.x() - self.gravity_compensation.x()) as i32;
+        self.ay += (accel.y() - self.gravity_compensation.y()) as i32;
+        self.az += (accel.z() - self.gravity_compensation.z()) as i32;
+        self.gx += gyro.x() as i32;
+        self.gy += gyro.y() as i32;
+        self.gz += gyro.z() as i32;
+    }
+
+    /// Compute average values (consumes `self` because the computation is done)
+    pub fn means(mut self) -> (Accel, Gyro) {
+        self.ax /= ITERATIONS as i32;
+        self.ay /= ITERATIONS as i32;
+        self.az /= ITERATIONS as i32;
+        self.gx /= ITERATIONS as i32;
+        self.gy /= ITERATIONS as i32;
+        self.gz /= ITERATIONS as i32;
+        (
+            Accel::new(self.ax as i16, self.ay as i16, self.az as i16),
+            Gyro::new(self.gx as i16, self.gy as i16, self.gz as i16),
+        )
+    }
+}
+
+/// Number of warmup iterations (when values are discardet)
+const WARMUP_ITERATIONS: usize = 30;
+/// Number of iterations for average error computation
+const ITERATIONS: usize = 200;
+/// Delay between measurements
+const DELAY_MS: u32 = 2;
+
+/// Perform a single loop computing the means of the readings
+pub fn collect_mean_values<I2c>(
+    mpu: &mut Mpu6050<I2c>,
+    delay: &mut impl DelayMs<u32>,
+    accel_scale: AccelFullScale,
+    gravity: ReferenceGravity,
+) -> Result<(Accel, Gyro), Error<I2c>>
+where
+    I2c: Write + WriteRead,
+    <I2c as WriteRead>::Error: core::fmt::Debug,
+    <I2c as Write>::Error: core::fmt::Debug,
+{
+    let mut accumulator = MeanAccumulator::new(accel_scale, gravity);
+
+    for _ in 0..WARMUP_ITERATIONS {
+        _ = mpu.accel()?;
+        _ = mpu.gyro()?;
+        delay.delay_ms(DELAY_MS);
+    }
+
+    for _ in 0..ITERATIONS {
+        let accel = mpu.accel()?;
+        let gyro = mpu.gyro()?;
+        accumulator.add(&accel, &gyro);
+        delay.delay_ms(DELAY_MS);
+    }
+
+    Ok(accumulator.means())
+}
+
+/// A single, full-fledged calibration loop (it also alters the device offest)
+pub fn calibration_loop<I2c>(
+    mpu: &mut Mpu6050<I2c>,
+    delay: &mut impl DelayMs<u32>,
+    parameters: &CalibrationParameters,
+    actions: CalibrationActions,
+) -> Result<(CalibrationActions, Accel, Gyro), Error<I2c>>
+where
+    I2c: Write + WriteRead,
+    <I2c as WriteRead>::Error: core::fmt::Debug,
+    <I2c as Write>::Error: core::fmt::Debug,
+{
+    let mut actions = actions;
+
+    mpu.set_accel_full_scale(parameters.accel_scale)?;
+    mpu.set_gyro_full_scale(parameters.gyro_scale)?;
+    let mut accel_offset = mpu.get_accel_calibration()?;
+    let mut gyro_offset = mpu.get_gyro_calibration()?;
+    let (accel_mean, gyro_mean) =
+        collect_mean_values(mpu, delay, parameters.accel_scale, parameters.gravity)?;
+
+    if parameters.accel_threshold.is_value_within(accel_mean.x()) {
+        actions = actions.with_accel_x(false);
+    }
+    if parameters.accel_threshold.is_value_within(accel_mean.y()) {
+        actions = actions.with_accel_y(false);
+    }
+    if parameters.accel_threshold.is_value_within(accel_mean.z()) {
+        actions = actions.with_accel_z(false);
+    }
+    if parameters.gyro_threshold.is_value_within(gyro_mean.x()) {
+        actions = actions.with_gyro_x(false);
+    }
+    if parameters.gyro_threshold.is_value_within(gyro_mean.y()) {
+        actions = actions.with_gyro_y(false);
+    }
+    if parameters.gyro_threshold.is_value_within(gyro_mean.z()) {
+        actions = actions.with_gyro_z(false);
+    }
+
+    if actions.accel_x() {
+        accel_offset.x = parameters
+            .accel_threshold
+            .next_offset(accel_mean.x(), accel_offset.x());
+    }
+    if actions.accel_y() {
+        accel_offset.y = parameters
+            .accel_threshold
+            .next_offset(accel_mean.y(), accel_offset.y());
+    }
+    if actions.accel_z() {
+        accel_offset.z = parameters
+            .accel_threshold
+            .next_offset(accel_mean.z(), accel_offset.z());
+    }
+    if actions.gyro_x() {
+        gyro_offset.x = parameters
+            .gyro_threshold
+            .next_offset(gyro_mean.x(), gyro_offset.x());
+    }
+    if actions.gyro_y() {
+        gyro_offset.y = parameters
+            .gyro_threshold
+            .next_offset(gyro_mean.y(), gyro_offset.y());
+    }
+    if actions.gyro_z() {
+        gyro_offset.z = parameters
+            .gyro_threshold
+            .next_offset(gyro_mean.z(), gyro_offset.z());
+    }
+
+    if !actions.is_empty() {
+        mpu.set_accel_calibration(&accel_offset)?;
+        mpu.set_gyro_calibration(&gyro_offset)?;
+    }
+
+    Ok((actions, accel_mean, gyro_mean))
+}
+
+/// Repeatedly perform calibration loops until the errors are within the given thresholds
+pub fn calibrate<I2c>(
+    mpu: &mut Mpu6050<I2c>,
+    delay: &mut impl DelayMs<u32>,
+    parameters: &CalibrationParameters,
+) -> Result<(Accel, Gyro), Error<I2c>>
+where
+    I2c: Write + WriteRead,
+    <I2c as WriteRead>::Error: core::fmt::Debug,
+    <I2c as Write>::Error: core::fmt::Debug,
+{
+    let mut actions = CalibrationActions::all();
+    while !actions.is_empty() {
+        (actions, _, _) = calibration_loop(mpu, delay, parameters, actions)?;
+    }
+    Ok((mpu.get_accel_calibration()?, mpu.get_gyro_calibration()?))
+}

--- a/src/gyro.rs
+++ b/src/gyro.rs
@@ -1,12 +1,18 @@
-#[derive(Copy, Clone, Debug)]
+/// Raw gyro readings vector.
+/// Also used to represent gyro calibration offsets.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct Gyro {
-    x: i16,
-    y: i16,
-    z: i16,
+    pub(crate) x: i16,
+    pub(crate) y: i16,
+    pub(crate) z: i16,
 }
 
 impl Gyro {
-    pub(crate) fn new(data: [u8; 6]) -> Self {
+    pub fn new(x: i16, y: i16, z: i16) -> Self {
+        Self { x, y, z }
+    }
+
+    pub fn from_bytes(data: [u8; 6]) -> Self {
         let x = [data[0], data[1]];
         let y = [data[2], data[3]];
         let z = [data[4], data[5]];
@@ -15,6 +21,13 @@ impl Gyro {
             y: i16::from_be_bytes(y),
             z: i16::from_be_bytes(z),
         }
+    }
+
+    pub fn to_bytes(&self) -> [u8; 6] {
+        let x = self.x.to_be_bytes();
+        let y = self.y.to_be_bytes();
+        let z = self.z.to_be_bytes();
+        [x[0], x[1], y[0], y[1], z[0], z[1]]
     }
 
     pub fn x(&self) -> i16 {

--- a/src/gyro.rs
+++ b/src/gyro.rs
@@ -28,6 +28,14 @@ impl Gyro {
     pub fn z(&self) -> i16 {
         self.z
     }
+
+    pub fn scaled(&self, scale: GyroFullScale) -> GyroF32 {
+        GyroF32 {
+            x: scale.scale_value(self.x),
+            y: scale.scale_value(self.y),
+            z: scale.scale_value(self.z),
+        }
+    }
 }
 
 #[derive(Copy, Clone, Debug)]
@@ -36,4 +44,39 @@ pub enum GyroFullScale {
     Deg500 = 1,
     Deg1000 = 2,
     Deg2000 = 3,
+}
+
+impl GyroFullScale {
+    pub const fn scale(self) -> f32 {
+        match self {
+            GyroFullScale::Deg250 => 131.0,
+            GyroFullScale::Deg500 => 65.5,
+            GyroFullScale::Deg1000 => 32.8,
+            GyroFullScale::Deg2000 => 16.4,
+        }
+    }
+
+    pub fn scale_value(self, value: i16) -> f32 {
+        (value as f32) / self.scale()
+    }
+}
+
+pub struct GyroF32 {
+    x: f32,
+    y: f32,
+    z: f32,
+}
+
+impl GyroF32 {
+    pub fn x(&self) -> f32 {
+        self.x
+    }
+
+    pub fn y(&self) -> f32 {
+        self.y
+    }
+
+    pub fn z(&self) -> f32 {
+        self.z
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@
 
 pub mod accel;
 pub mod address;
+pub mod calibration;
 pub mod clock_source;
 pub mod config;
 mod dmp_firmware;

--- a/src/sensor.rs
+++ b/src/sensor.rs
@@ -1,5 +1,9 @@
 use crate::accel::{Accel, AccelFullScale};
 use crate::address::Address;
+use crate::calibration::{
+    calibrate, calibration_loop, collect_mean_values, CalibrationActions, CalibrationParameters,
+    ReferenceGravity,
+};
 use crate::clock_source::ClockSource;
 use crate::config::DigitalLowPassFilter;
 use crate::error::Error;
@@ -132,13 +136,17 @@ where
 
     /// Super simple averaging calibration of the accelerometers.
     /// Probably should be called before initializing the DMP.
+    /// Deprecated because the new calibration framework (`calibrate`) works way better.
     // TODO that's obviously not optimal situation, fix this with typestates or something.
     // TODO: consider this: https://wired.chillibasket.com/2015/01/calibrating-mpu6050/
+    #[deprecated]
     pub fn calibrate_accel(
         &mut self,
         loops: u8,
         delay: &mut impl delay::DelayMs<u32>,
     ) -> Result<(), Error<I2c>> {
+        self.set_accel_calibration(&Accel::new(0, 0, 0))?;
+
         delay.delay_ms(10);
         let mut accumulator = [0i16; 3];
         for _ in 0..loops {
@@ -149,53 +157,161 @@ where
             delay.delay_ms(1);
         }
 
-        let h = ((accumulator[0]) << 8) as u8;
-        let l = (accumulator[0] & 0x00FF) as u8;
-        self.write(&[Register::AccelOffsetX_H as u8, h, l])?;
-
-        let h = ((accumulator[1]) << 8) as u8;
-        let l = (accumulator[1] & 0x00FF) as u8;
-        self.write(&[Register::AccelOffsetY_H as u8, h, l])?;
-
-        let h = ((accumulator[2]) << 8) as u8;
-        let l = (accumulator[2] & 0x00FF) as u8;
-        self.write(&[Register::AccelOffsetZ_H as u8, h, l])?;
+        let values = Accel::new(accumulator[0], accumulator[1], accumulator[2]);
+        self.set_accel_calibration(&values)?;
 
         Ok(())
     }
 
     /// Super simple averaging calibration of the gyroscopes.
     /// Probably should be called before initializing the DMP.
+    /// Deprecated because the new calibration framework (`calibrate`) works way better.
     // TODO that's obviously not optimal situation, fix this with typestates or something.
     // TODO: consider this: https://wired.chillibasket.com/2015/01/calibrating-mpu6050/
+    #[deprecated]
     pub fn calibrate_gyro(
         &mut self,
         loops: u8,
         delay: &mut impl delay::DelayMs<u32>,
     ) -> Result<(), Error<I2c>> {
+        self.set_gyro_calibration(&Gyro::new(0, 0, 0))?;
+
         delay.delay_ms(10);
         let mut accumulator = [0i16; 3];
         for _ in 0..loops {
-            let gyros = self.gyro().unwrap();
+            let gyros = self.gyro()?;
             accumulator[0] += (gyros.x() as f32 / loops as f32) as i16;
             accumulator[1] += (gyros.y() as f32 / loops as f32) as i16;
             accumulator[2] += (gyros.z() as f32 / loops as f32) as i16;
             delay.delay_ms(1);
         }
 
-        let h = ((accumulator[0]) << 8) as u8;
-        let l = (accumulator[0] & 0x00FF) as u8;
-        self.write(&[Register::GyroOffsetX_H as u8, h, l])?;
-
-        let h = ((accumulator[1]) << 8) as u8;
-        let l = (accumulator[1] & 0x00FF) as u8;
-        self.write(&[Register::GyroOffsetY_H as u8, h, l])?;
-
-        let h = ((accumulator[2]) << 8) as u8;
-        let l = (accumulator[2] & 0x00FF) as u8;
-        self.write(&[Register::GyroOffsetZ_H as u8, h, l])?;
+        let values = Gyro::new(accumulator[0], accumulator[1], accumulator[2]);
+        self.set_gyro_calibration(&values)?;
 
         Ok(())
+    }
+
+    /// Through calibration, taken from https://wired.chillibasket.com/2015/01/calibrating-mpu6050/
+    /// This is supposed to be run once, printing the results, and reusing them by setting the
+    /// calibration using `set_accel_calibration` and `set_gyro_calibration` with offsets hardcoded
+    /// as constants in the application code (or storing and retrieving them to-from persistent
+    /// storage, if available).
+    /// If calibration parameters are not "reasonable" this function might never return.
+    pub fn calibrate(
+        &mut self,
+        delay: &mut impl delay::DelayMs<u32>,
+        parameters: &CalibrationParameters,
+    ) -> Result<(Accel, Gyro), Error<I2c>> {
+        calibrate(self, delay, parameters)
+    }
+
+    /// A building block for performing calibration: collect several samples return their average
+    pub fn collect_mean_values(
+        &mut self,
+        delay: &mut impl delay::DelayMs<u32>,
+        accel_scale: AccelFullScale,
+        gravity: ReferenceGravity,
+    ) -> Result<(Accel, Gyro), Error<I2c>> {
+        collect_mean_values(self, delay, accel_scale, gravity)
+    }
+
+    /// A higher level building block for performing calibration.
+    /// This function should be called repeatedly, until `is_empty()` returns `true` on the
+    /// returned `CalibrationActions`.
+    ///
+    /// At each iteration the calibration gets "better", and it is considered completed when
+    /// there are no more actions to perform.
+    ///
+    /// This is an example of how a calibration loop can be written:
+    ///
+    /// ```ignore
+    ///     let calibration_parameters =
+    ///         CalibrationParameters::new(ACCEL_SCALE, GYRO_SCALE, ReferenceGravity::ZN);
+    ///     let mut actions = CalibrationActions::all();
+    ///     let mut accel_error: Accel;
+    ///     let mut gyro_error: Gyro;
+    ///     while !actions.is_empty() {
+    ///         (actions, accel_error, gyro_error) = mpu
+    ///             .calibration_loop(&mut delay, &calibration_parameters, actions)
+    ///             .unwrap();
+    ///         uprintln!(
+    ///             serial,
+    ///             "errors: [a {} {} {}] [g {} {} {}] [done: {}]",
+    ///             accel_error.x(),
+    ///             accel_error.y(),
+    ///             accel_error.z(),
+    ///             gyro_error.x(),
+    ///             gyro_error.y(),
+    ///             gyro_error.z(),
+    ///             actions.is_empty(),
+    ///         );
+    ///     }
+    ///     let accel_offset = mpu.get_accel_calibration().unwrap();
+    ///     let gyro_offset = mpu.get_gyro_calibration().unwrap();
+    ///     uprintln!(
+    ///         serial,
+    ///         "offsets: [a {} {} {}] [g {} {} {}]",
+    ///         accel_offset.x(),
+    ///         accel_offset.y(),
+    ///         accel_offset.z(),
+    ///         gyro_offset.x(),
+    ///         gyro_offset.y(),
+    ///         gyro_offset.z(),
+    ///     );
+    /// ```
+    ///
+    /// When the loop is done the offsets can be collected and hardcoded in the initialization
+    /// of the application that will use this device with exactly these settings.
+
+    /// Perform a full device calibration (note that this function might never terminate).
+    pub fn calibration_loop(
+        &mut self,
+        delay: &mut impl delay::DelayMs<u32>,
+        parameters: &CalibrationParameters,
+        actions: CalibrationActions,
+    ) -> Result<(CalibrationActions, Accel, Gyro), Error<I2c>> {
+        calibration_loop(self, delay, parameters, actions)
+    }
+
+    pub fn get_accel_calibration(&mut self) -> Result<Accel, Error<I2c>> {
+        let mut data = [0; 6];
+        self.read_registers(Register::AccelOffsetX_H, &mut data)?;
+        Ok(Accel::from_bytes(data))
+    }
+
+    pub fn get_gyro_calibration(&mut self) -> Result<Gyro, Error<I2c>> {
+        let mut data = [0; 6];
+        self.read_registers(Register::GyroOffsetX_H, &mut data)?;
+        Ok(Gyro::from_bytes(data))
+    }
+
+    pub fn set_accel_calibration(&mut self, values: &Accel) -> Result<(), Error<I2c>> {
+        let data = values.to_bytes();
+        let bytes = [
+            Register::AccelOffsetX_H as u8,
+            data[0],
+            data[1],
+            data[2],
+            data[3],
+            data[4],
+            data[5],
+        ];
+        self.write(&bytes)
+    }
+
+    pub fn set_gyro_calibration(&mut self, values: &Gyro) -> Result<(), Error<I2c>> {
+        let data = values.to_bytes();
+        let bytes = [
+            Register::GyroOffsetX_H as u8,
+            data[0],
+            data[1],
+            data[2],
+            data[3],
+            data[4],
+            data[5],
+        ];
+        self.write(&bytes)
     }
 
     pub fn set_accel_full_scale(&mut self, scale: AccelFullScale) -> Result<(), Error<I2c>> {
@@ -296,12 +412,12 @@ where
     pub fn accel(&mut self) -> Result<Accel, Error<I2c>> {
         let mut data = [0; 6];
         self.read_registers(Register::AccelX_H, &mut data)?;
-        Ok(Accel::new(data))
+        Ok(Accel::from_bytes(data))
     }
 
     pub fn gyro(&mut self) -> Result<Gyro, Error<I2c>> {
         let mut data = [0; 6];
         self.read_registers(Register::GyroX_H, &mut data)?;
-        Ok(Gyro::new(data))
+        Ok(Gyro::from_bytes(data))
     }
 }


### PR DESCRIPTION
This branch adds two things:

- scaling values (the first commit)
- a PID based, adaptive calibration system (the second commit)

The calibration system is well described in the comments.

The trickiest part is that with wrong parameters the configuration might never converge, but without progress reports these situations are heard to troubleshoot.
Hoever, I did not want to add "print statements" to each iteration because this code is supposed to run on embedded systems where `println!` might not be available.

My solution has been to design an API that is usable iteratively, so that the user is in control of the calibration iterations, they can follow the progress (errors should become smaller at each iteration), and detect situations where the offset search does not converge.
An example of this kind of use is in the doc comments of the relevant function.