### PR TITLE
Add interrupt enable API

### DIFF
--- a/src/registers.rs
+++ b/src/registers.rs
@@ -39,6 +39,7 @@ pub enum Register {
 
     UserCtrl = 0x6A,
     IntEnable = 0x38,
+    IntStatus = 0x3A,
 
     FifoEn = 0x23,
     FifoCount_H = 0x72,

--- a/src/sensor.rs
+++ b/src/sensor.rs
@@ -142,6 +142,27 @@ where
         self.write_register(Register::IntEnable, 0x00)
     }
 
+    /// Enables a FIFO buffer overflow to generate an interrupt
+    pub fn interrupt_fifo_oflow_en(&mut self) -> Result<(), Error<I2c>> {
+        self.write_register(Register::IntEnable, 0b0001_0000)
+    }
+
+    /// Enables any of the i2c master interrupt sources to generate an interrupt
+    pub fn interrupt_i2c_mst_int_en(&mut self) -> Result<(), Error<I2c>> {
+        self.write_register(Register::IntEnable, 0b0000_1000)
+    }
+
+    /// Enables the Data Ready interrupt, which occurs each time a write
+    /// operation to all of the sensor registers has been completed
+    pub fn interrupt_data_ready_en(&mut self) -> Result<(), Error<I2c>> {
+        self.write_register(Register::IntEnable, 0b1000_0000)
+    }
+
+    /// Read the interrupt status register and clear it.
+    pub fn interrupt_read_clear(&mut self) -> Result<u8, Error<I2c>> {
+        self.read_register(Register::IntStatus)
+    }
+
     /// Super simple averaging calibration of the accelerometers.
     /// Probably should be called before initializing the DMP.
     /// Deprecated because the new calibration framework (`calibrate`) works way better.


### PR DESCRIPTION
Couple of one liners.

4.15 Register 56 – Interrupt Enable INT_ENABLE (0x38)
4.16 Register 58 – Interrupt Status INT_STATUS (0x3A)

p. 27 & 28 of the register map sheet.

I have tested them on my own hardware (well, just fifo oflow and data ready) but if there's any standard you need before merging this in let me know!