### PR TITLE
chore(test): add test with real calibration data that overflows

### DIFF
--- a/src/calibration.rs
+++ b/src/calibration.rs
@@ -344,3 +344,67 @@ impl MeanAccumulator {
         )
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::{
+        accel::{Accel, AccelFullScale},
+        gyro::Gyro,
+    };
+
+    use super::{MeanAccumulator, ReferenceGravity};
+
+    #[test]
+    fn test_mean_accumulator_with_compensation() {
+        // Case #1: attempt to subtract with overflow
+        {
+            let accel = Accel {
+                x: -1180,
+                y: -32768,
+                z: 32767,
+            };
+            let gyro = Gyro {
+                x: -3,
+                y: -7,
+                z: -10,
+            };
+
+            let mut mean_acc = MeanAccumulator::new(AccelFullScale::G2, ReferenceGravity::ZN);
+            mean_acc.add(&accel, &gyro);
+
+            assert_eq!(mean_acc.az, 32767 - 16384);
+        }
+    }
+
+    #[test]
+    fn test_mean_accumulator_with_compensation_negate_panic() {
+        // Case #2: attempt to subtract with overflow
+        {
+            let mut mean_acc = MeanAccumulator {
+                ax: -700924,
+                ay: -6520832,
+                az: 3260217,
+                gx: -3345,
+                gy: 770,
+                gz: -7648,
+                gravity_compensation: Accel {
+                    x: 0,
+                    y: 0,
+                    z: -16384,
+                },
+            };
+            let accel = Accel {
+                x: -3536,
+                y: -32768,
+                z: 32767,
+            };
+            let gyro = Gyro {
+                x: -105,
+                y: 100,
+                z: -36,
+            };
+
+            mean_acc.add(&accel, &gyro);
+        }
+    }
+}


### PR DESCRIPTION
Testing my IMU I found this cases where the calibration calculation overflows for the `z` axis `add` call so I added test here to demonstrate the issue with real data.

I managed to get rid of the overflow but then I got to a different error which was about: `attempt to negate with overflow`

Since there's no issues enabled for this repo, I decided to open the PR here and discuss it.

PS: I will open another PR for adding defmt, crate looks great and I should have take a look at the repo as it now has async support :tada: . I would love to see this version also released :crossed_fingers: 