### PR TITLE
feat: Sensor - motion6 6 dof with one registry read

### DIFF
--- a/src/sensor.rs
+++ b/src/sensor.rs
@@ -437,4 +437,14 @@ where
         self.read_registers(Register::GyroX_H, &mut data)?;
         Ok(Gyro::from_bytes(data))
     }
+
+    /// Gets the 6 degrees of freedom at once - Acceleration and Gyroscope.
+    pub fn motion6(&mut self) -> Result<(Accel, Gyro), Error<I>> {
+        let mut data = [0; 14];
+        self.read_registers(Register::AccelX_H, &mut data)?;
+
+        let accel = Accel::from_bytes([data[0], data[1], data[2], data[3], data[4], data[5]]);
+        let gyro = Gyro::from_bytes([data[8], data[9], data[10], data[11], data[12], data[13]]);
+        Ok((accel, gyro))
+    }
 }

--- a/src/sensor_async.rs
+++ b/src/sensor_async.rs
@@ -396,4 +396,16 @@ where
         self.read_registers(Register::GyroX_H, &mut data).await?;
         Ok(Gyro::from_bytes(data))
     }
+
+    /// Gets the 6 degrees of freedom at once - Acceleration and Gyroscope.
+    pub async fn motion6(&mut self) -> Result<(Accel, Gyro), Error<I>> {
+        let mut data = [0; 14];
+        self.read_registers(Register::AccelX_H, &mut data).await?;
+
+        let accel = Accel::from_bytes([
+            data[0], data[1], data[2], data[3], data[4], data[5],
+        ]);
+        let gyro = Gyro::from_bytes([data[8], data[9], data[10], data[11], data[12], data[13]]);
+        Ok((accel, gyro))
+    }
 }


### PR DESCRIPTION
I got the optimization from a C arduino library that reads a few more bytes in the buffer but gets both the accel & gyro data with a single read making the reading of the IMIU data faster.
Applications that will benefit from this optimization are e.g. flight controller firmware.

I'm open to suggestions for the fn name.