### PR TITLE
Add temperature sensor

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,9 +14,10 @@ repository = "https://github.com/barafael/mpu6050-dmp-rs"
 readme = "README.md"
 
 [features]
-default = []
+default = ["temperature"]
 defmt-03 = ["dep:defmt"]
 async = ["dep:embedded-hal-async"]
+temperature = []
 
 [dependencies]
 embedded-hal = { version = "1" }

--- a/README.md
+++ b/README.md
@@ -45,6 +45,16 @@ let i2c = dp.I2C1.i2c((scl, sda), 400.kHz(), &clocks);
 let sensor = Mpu6050::new(i2c, Address::default()).unwrap();
 ```
 
+### Temperature Measurement
+
+The MPU-6050 includes an on-chip temperature sensor. Temperature readings are available through the `temperature()` method when the `temperature` feature is enabled (enabled by default):
+
+```rust
+// Get temperature reading
+let temp = sensor.temperature().unwrap();
+println!("Temperature: {}°C", temp.celsius());
+```
+
 Setting up the DMP requires temporary exclusive access to a blocking delay implementation.
 The `initialize_dmp(&mut delay)` method is provided to set up reasonable configurations and load the DMP firmware into the processor.
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,4 +24,6 @@ pub mod registers;
 pub mod sensor;
 #[cfg(feature = "async")]
 pub mod sensor_async;
+#[cfg(feature = "temperature")]
+pub mod temperature;
 pub mod yaw_pitch_roll;

--- a/src/registers.rs
+++ b/src/registers.rs
@@ -27,6 +27,9 @@ pub enum Register {
     AccelZ_H = 0x3F,
     AccelZ_L = 0x40,
 
+    TempOut_H = 0x41,
+    TempOut_L = 0x42,
+
     AccelConfig = 0x1C,
 
     GyroX_H = 0x43,

--- a/src/sensor.rs
+++ b/src/sensor.rs
@@ -450,6 +450,27 @@ where
         Ok((accel, gyro))
     }
 
+    /// Read the current temperature from the sensor's internal temperature sensor.
+    ///
+    /// Note: This measures the internal temperature of the MPU-6050 chip itself,
+    /// not the ambient room temperature. Due to self-heating during operation,
+    /// readings will typically be a few degrees higher than the ambient temperature.
+    /// This can be useful for monitoring the device's temperature but should not be
+    /// used for ambient temperature measurement.
+    ///
+    /// Returns a [`Temperature`] struct that can convert the reading to degrees Celsius
+    /// using the [`Temperature::celsius()`] method. This is the recommended way to get
+    /// the temperature in a standard unit.
+    ///
+    /// Note: This method is only available when the "temperature" feature is enabled.
+    ///
+    /// # Example
+    /// ```
+    /// # use mpu6050_dmp::Mpu6050;
+    /// # let mut mpu = // ... initialize MPU-6050
+    /// let temp = mpu.temperature()?;
+    /// let celsius = temp.celsius(); // Get temperature in degrees Celsius
+    /// ```
     #[cfg(feature = "temperature")]
     pub fn temperature(&mut self) -> Result<Temperature, Error<I>> {
         let mut data = [0; 2];

--- a/src/sensor.rs
+++ b/src/sensor.rs
@@ -1,3 +1,5 @@
+#[cfg(feature = "temperature")]
+use crate::temperature::Temperature;
 use crate::{
     accel::{Accel, AccelFullScale},
     address::Address,
@@ -446,5 +448,12 @@ where
         let accel = Accel::from_bytes([data[0], data[1], data[2], data[3], data[4], data[5]]);
         let gyro = Gyro::from_bytes([data[8], data[9], data[10], data[11], data[12], data[13]]);
         Ok((accel, gyro))
+    }
+
+    #[cfg(feature = "temperature")]
+    pub fn temperature(&mut self) -> Result<Temperature, Error<I>> {
+        let mut data = [0; 2];
+        self.read_registers(Register::TempOut_H, &mut data)?;
+        Ok(Temperature::from_bytes(data))
     }
 }

--- a/src/sensor_async.rs
+++ b/src/sensor_async.rs
@@ -1,3 +1,5 @@
+#[cfg(feature = "temperature")]
+use crate::temperature::Temperature;
 use crate::{
     accel::{Accel, AccelFullScale},
     address::Address,
@@ -402,10 +404,15 @@ where
         let mut data = [0; 14];
         self.read_registers(Register::AccelX_H, &mut data).await?;
 
-        let accel = Accel::from_bytes([
-            data[0], data[1], data[2], data[3], data[4], data[5],
-        ]);
+        let accel = Accel::from_bytes([data[0], data[1], data[2], data[3], data[4], data[5]]);
         let gyro = Gyro::from_bytes([data[8], data[9], data[10], data[11], data[12], data[13]]);
         Ok((accel, gyro))
+    }
+
+    #[cfg(feature = "temperature")]
+    pub async fn temperature(&mut self) -> Result<Temperature, Error<I>> {
+        let mut data = [0; 2];
+        self.read_registers(Register::TempOut_H, &mut data).await?;
+        Ok(Temperature::from_bytes(data))
     }
 }

--- a/src/temperature.rs
+++ b/src/temperature.rs
@@ -1,4 +1,25 @@
-/// Raw temperature reading
+/// Temperature reading from the MPU-6050's internal temperature sensor.
+///
+/// Note: This measures the temperature of the MPU-6050 chip itself, not the ambient
+/// room temperature. The sensor readings will typically be a few degrees higher than
+/// the ambient temperature due to self-heating of the device during operation.
+///
+/// The raw temperature value from the sensor needs to be converted using a formula
+/// from the datasheet to get the actual temperature in degrees Celsius.
+/// While the raw value is available via [`raw()`], you should typically use [`celsius()`]
+/// to get the temperature in a standard unit.
+///
+/// # Example
+/// ```
+/// # use mpu6050_dmp::temperature::Temperature;
+/// let temp = Temperature::new(3990);
+///
+/// // Get temperature in Celsius (recommended)
+/// let celsius = temp.celsius(); // Returns ~48.26°C
+///
+/// // Get raw value (typically not needed)
+/// let raw = temp.raw(); // Returns 3990
+/// ```
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "defmt-03", derive(defmt::Format))]
 pub struct Temperature {
@@ -20,6 +41,11 @@ impl Temperature {
         self.raw.to_be_bytes()
     }
 
+    /// Returns the raw temperature value from the sensor.
+    ///
+    /// Note: In most cases, you should use [`celsius()`] instead to get the temperature
+    /// in degrees Celsius. The raw value is primarily useful for debugging or
+    /// custom temperature conversion implementations.
     pub fn raw(&self) -> i16 {
         self.raw
     }

--- a/src/temperature.rs
+++ b/src/temperature.rs
@@ -1,0 +1,32 @@
+/// Raw temperature reading
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt-03", derive(defmt::Format))]
+pub struct Temperature {
+    pub(crate) raw: i16,
+}
+
+impl Temperature {
+    pub fn new(raw: i16) -> Self {
+        Self { raw }
+    }
+
+    pub fn from_bytes(data: [u8; 2]) -> Self {
+        Self {
+            raw: i16::from_be_bytes(data),
+        }
+    }
+
+    pub fn to_bytes(&self) -> [u8; 2] {
+        self.raw.to_be_bytes()
+    }
+
+    pub fn raw(&self) -> i16 {
+        self.raw
+    }
+
+    /// Convert raw temperature to degrees Celsius
+    /// Formula from datasheet: Temperature = (TEMP_OUT)/340 + 36.53
+    pub fn celsius(&self) -> f32 {
+        (self.raw as f32) / 340.0 + 36.53
+    }
+}


### PR DESCRIPTION
When tinkering with my sensor I found the driver to work very well - but I was missing the temperature measurement that I found referred to in videos and tutorials for Arduino and/or Micropython. So I set an agent AI to the task of rummaging around and adding this feature.

I have tested the addition, I get sensible readings. BUT(!) have a good look at my assumptions:

+ I have added this as a default feature, all chips should support it, but what do I know -> so people can opt out. Maybe this should not even be behind a feature? Or not a default one?
+ I am assuming the temp reading is for the device temperature and not the ambient temperature, at least I cannot imagine how this tiny thing with no visible air inlet, circulation thingy or whatever could measure ambient temp. Am I right here? It measures a few degrees above ambient, and that makes senseto me if I am assuming right.
+ In general I am a Rust newbie and augmented with AI -> so think of a toddler with a gun. Warrants a look at the code, I believe. 